### PR TITLE
REFACTORING-1: 중복되는 버튼 속성 mixin 사용하여 정리, 일부 레이아웃 수정

### DIFF
--- a/src/common/Button.scss
+++ b/src/common/Button.scss
@@ -1,0 +1,38 @@
+@import '../styles/colors';
+@mixin btn_effect {
+  background-color: $main-mint;
+  box-shadow: 0 8px 20px $main-mint-dark;
+  color: #fff;
+  transform: translateY(-7px);
+}
+@mixin btn_standard {
+  /* btn size */
+  width: 140px;
+  height: 45px;
+
+  /* btn font */
+  color: #000;
+  font-size: 0.9em;
+  font-weight: 500;
+  letter-spacing: 2.5px;
+
+  border: none;
+  border-radius: 45px;
+  background-color: #fff;
+  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
+
+  cursor: pointer;
+  outline: none;
+  margin-bottom: 2rem;
+
+  transition: all 0.3s ease 0s;
+
+  @media (any-hover: hover) {
+    &:hover {
+      @include btn_effect;
+    }
+  }
+  &:active{
+    @include btn_effect;
+  }
+}

--- a/src/common/MainWrapper.scss
+++ b/src/common/MainWrapper.scss
@@ -1,3 +1,5 @@
+@import './Button';
+
 #landscape { display: none; }
 
 @media only screen and (device-width: 768px) and (orientation:landscape){
@@ -14,14 +16,27 @@
     position: relative;
     margin: 0 auto;
     background-color: #fff;
-    box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+    box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
 
     display: flex;
     align-items: center;
     justify-content: center;
     flex-direction: column;
     text-align: center;
-  
+
+    box-sizing: border-box;
+    @media only screen and (max-width: 480px) {
+        padding: 1rem;
+    }
+    padding: 1rem 2rem;
+
+    button {
+        @include btn_standard;
+    }
+
+    h1 {
+        margin-top: 0;
+    }
 }
 
 

--- a/src/components/AnswerBox.js
+++ b/src/components/AnswerBox.js
@@ -5,10 +5,10 @@ const AnswerBox = ({ FIRST_ANSWER, SECOND_ANSWER, idx, value, onClickListHandler
         <>
             <span>Q{idx+1}. {value[0]}</span>
             <section>
-                <button id={FIRST_ANSWER} onClick={ e => onClickListHandler(e) }>
+                <button id={FIRST_ANSWER} onClick={ e => onClickListHandler(e) } className={'btn_test'}>
                     {value[1]}
                 </button>
-                <button id={SECOND_ANSWER} onClick={ e => onClickListHandler(e) }>
+                <button id={SECOND_ANSWER} onClick={ e => onClickListHandler(e) } className={'btn_test'}>
                     {value[2]}
                 </button>
             </section>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -47,7 +47,7 @@ function Modal(
                 <ModalInner tabIndex="0" className="modal-inner">
                     {children}
                     <div className="link-copy-container">
-                        <textarea id="url-textarea" className="url-textarea" type="text" value={currentURL} />
+                        <textarea id="url-textarea" className="url-textarea" value={currentURL} />
                         <button className="link-copy-btn" type="button" onClick={copyToClipboard}>copy</button>
                     </div>
                     <SnsShareButton name="twitter" />
@@ -105,7 +105,10 @@ const ModalInner = styled.div`
   top: 50%;
   transform: translateY(-50%);
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 30px 20px;
+  h3 {
+    margin-top: 0;
+  }
 `
 
 export default Modal;

--- a/src/components/Profiles.js
+++ b/src/components/Profiles.js
@@ -9,10 +9,10 @@ function Profiles({ name, image, desc, position, instaLogo, instaLink }) {
 
             <div className="profiles-detail">
                 <img src={image} alt="profile" className="pictures"/>
-            
-                <span className="maker-name">{name}</span>
-
+            <div className="div_maker_container">
                 <span className="maker-position">{position}</span>
+                <span className="maker-name">{name}</span>
+            </div>
             </div>
                 
             

--- a/src/components/Profiles.scss
+++ b/src/components/Profiles.scss
@@ -2,21 +2,16 @@
 
    
     .profiles-wrapper {
+        box-sizing: border-box;
+        width: 100%;
         border-radius: 16px;
         background-color: #fff;
         display: flex;
         flex-direction: column;
-        padding: 3rem;
-        box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+        padding: 1em 2em;
+        box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
         justify-content: center;
         align-items: center;
-
-        @media only screen and (max-width: 480px) {
-            width: 70%;
-            
-        }
-        
-
 
       .profiles-detail{
         display: flex;
@@ -26,36 +21,35 @@
             width: 100px;
             height: 100px;
             border-radius: 50%;
-            box-shadow: rgba(0, 0, 0, 0.09) 0px 2px 1px, rgba(0, 0, 0, 0.09) 0px 4px 2px, rgba(0, 0, 0, 0.09) 0px 8px 4px, rgba(0, 0, 0, 0.09) 0px 16px 8px, rgba(0, 0, 0, 0.09) 0px 32px 16px;
+            box-shadow: rgba(0, 0, 0, 0.09) 0 2px 1px, rgba(0, 0, 0, 0.09) 0 4px 2px, rgba(0, 0, 0, 0.09) 0 8px 4px, rgba(0, 0, 0, 0.09) 0 16px 8px, rgba(0, 0, 0, 0.09) 0 32px 16px;
+            margin-right: 4rem;
+        }
+        .div_maker_container {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+
+            span + span {
+                margin-top: 0.1em;
+            }
         }
         .maker-name {
-            display: flex;
-            align-items: center;
-            margin-left: 2rem;
+            @media only screen and (max-width: 480px) {
+                font-size: 1.2em;
+            }
+            font-size: 1.5em;
         }
         .maker-position {
-
-            display: flex;
-            align-items: center;
-            margin-left: 2rem;
-            padding: 1rem;
-            height: 30px;
-            font-size: 11px;
-            letter-spacing: 2.5px;
-            font-weight: 500;
-            border: none;
-            border-radius: 45px;
-            outline: none;
-
-       
-            background-color: #2EE59D;;
-            box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-            color: #fff;
-       
-
-
-
-        
+            @media only screen and (max-width: 480px) {
+                font-size: 0.6em;
+            }
+            display: block;
+            font-size: 0.8em;
+            background: #ccc;
+            color: #fcfcfc;
+            padding: 0.1em 0.5em;
+            border-radius: 20px;
         }
     }
         
@@ -70,14 +64,6 @@
         }
     }
 
-    
-    
-
-
-
 .profiles-wrapper + .profiles-wrapper {
     margin-top: 2rem;
-    
 }
-
-   

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -24,7 +24,7 @@ function Main() {
     return (
   
 
-        <MainWrapper className="main-wrapper">
+        <MainWrapper>
             { showAlert ? <AlertBox display={display} onClick={cancelBox}/> : null}
            
             <h2>성격으로 알아보자!</h2>

--- a/src/pages/Makers.js
+++ b/src/pages/Makers.js
@@ -22,7 +22,7 @@ function Makers() {
             id: 2,
             name: '박나리(INTP)',
             image: nr,
-            desc: '',
+            desc: ':P',
             position: '개발자'
         },
         {
@@ -36,7 +36,7 @@ function Makers() {
     ]
 
     return (
-            <MainWrapper className="main-wrapper">
+            <MainWrapper>
                 <h1>만든이들</h1>
 
                 <Link to="/">

--- a/src/pages/Result.js
+++ b/src/pages/Result.js
@@ -30,7 +30,7 @@ function Result({ location }) {
     
     if (loading) return <MainWrapper><Loading /></MainWrapper>
     return (
-    <MainWrapper className="main-wrapper">
+    <MainWrapper>
         <div className="result-inner">
             <h1>당신은 <span className="artistname">{resultObj.artistName}</span>이시군요!</h1>
             <div className="desc-wrapper">
@@ -38,9 +38,7 @@ function Result({ location }) {
                 <img src={resultObj.drwsrc} className="result-img" alt="artist-drawing"></img>
                 <p className="result-desc">
                     {resultObj.description.split('\n').map((line) => {
-                        return <div style={{
-                            marginBottom: '1rem'
-                        }}>{line}</div>
+                        return <div>{line}</div>
                     })}
                 </p>
             </div>

--- a/src/pages/Test.js
+++ b/src/pages/Test.js
@@ -58,17 +58,17 @@ function Test({history}) {
 
     return (
         show &&
-        <MainWrapper className="main-wrapper">
-        <article className={ `test ${animation}` }>
-            <progress max={ TEST_LIST.length } value={ idx+1 } />
-            <AnswerBox
-                FIRST_ANSWER={ FIRST_ANSWER }
-                SECOND_ANSWER={ SECOND_ANSWER }
-                onClickListHandler={ onClickListHandler }
-                idx={ idx }
-                value={ TEST_LIST[idx] }
-            />
-        </article>
+        <MainWrapper>
+            <article className={ `test ${animation}` }>
+                <progress max={ TEST_LIST.length } value={ idx+1 } />
+                <AnswerBox
+                    FIRST_ANSWER={ FIRST_ANSWER }
+                    SECOND_ANSWER={ SECOND_ANSWER }
+                    onClickListHandler={ onClickListHandler }
+                    idx={ idx }
+                    value={ TEST_LIST[idx] }
+                />
+            </article>
         </MainWrapper>
     )
 }

--- a/src/styles/Main.scss
+++ b/src/styles/Main.scss
@@ -13,7 +13,7 @@
       letter-spacing: 2.5px;
       font-weight: 500;
       background-color: #2ee59d;
-      box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
+      box-shadow: 0 15px 20px rgba(46, 229, 157, 0.4);
       color: #fff;
     }
   }

--- a/src/styles/Makers.scss
+++ b/src/styles/Makers.scss
@@ -1,56 +1,59 @@
-
-
-@media only screen and (min-width: 480px) {
-   
-    button {
-        width: 140px;
-        height: 45px;
-        font-size: 11px;
-        letter-spacing: 2.5px;
-        font-weight: 500;
-        color: #000;
-        background-color: #fff;
-        border: none;
-        border-radius: 45px;
-        box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-        transition: all 0.3s ease 0s;
-        cursor: pointer;
-        outline: none;
-        margin-bottom: 2rem;
-
-        &:hover {
-            background-color: #2EE59D;;
-            box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-            color: #fff;
-            transform: translateY(-7px);
-        }
-
-    }
+.btn-back {
+  margin-bottom: 1rem !important;
 }
-    
-
-        @media only screen and (max-width: 480px) {
-
-            .main-wrapper {
-                width: 100%;
-                height: 100%;
-            }
-            button {
-                width: 140px;
-                height: 45px;
-                letter-spacing: 2.5px;
-                font-weight: 500;
-                background-color: #2EE59D;;
-                box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-                color: #fff;
-                cursor: pointer;
-                outline: none;
-                margin-bottom: 2rem;
-                border: none;
-                border-radius: 45px;
-                
-            }
-        }
+//
+//
+//@media only screen and (min-width: 480px) {
+//
+//    button {
+//        width: 140px;
+//        height: 45px;
+//        font-size: 11px;
+//        letter-spacing: 2.5px;
+//        font-weight: 500;
+//        color: #000;
+//        background-color: #fff;
+//        border: none;
+//        border-radius: 45px;
+//        box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
+//        transition: all 0.3s ease 0s;
+//        cursor: pointer;
+//        outline: none;
+//        margin-bottom: 2rem;
+//
+//        &:hover {
+//            background-color: #2EE59D;;
+//            box-shadow: 0 15px 20px rgba(46, 229, 157, 0.4);
+//            color: #fff;
+//            transform: translateY(-7px);
+//        }
+//
+//    }
+//}
+//
+//
+//@media only screen and (max-width: 480px) {
+//
+//    .main-wrapper {
+//        width: 100%;
+//        height: 100%;
+//    }
+//    button {
+//        width: 140px;
+//        height: 45px;
+//        letter-spacing: 2.5px;
+//        font-weight: 500;
+//        background-color: #2EE59D;;
+//        box-shadow: 0 15px 20px rgba(46, 229, 157, 0.4);
+//        color: #fff;
+//        cursor: pointer;
+//        outline: none;
+//        margin-bottom: 2rem;
+//        border: none;
+//        border-radius: 45px;
+//
+//    }
+//}
 
     
     

--- a/src/styles/Result.scss
+++ b/src/styles/Result.scss
@@ -1,64 +1,36 @@
-@import "colors";
-
+@import '../common/Button';
 .main-wrapper {
-  @media only screen and (min-width: 480px) {
-    .replay {
-      &:hover {
-        background-color: #2ee59d;
-        box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-        color: #fff;
-        transform: translateY(-7px);
-      }
-      width: 140px;
-      height: 45px;
-      font-size: 11px;
-      letter-spacing: 2.5px;
-      font-weight: 500;
-      color: #000;
-      background-color: #fff;
-      border: none;
-      box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-
-      cursor: pointer;
-      outline: none;
+  .replay {
+    @media only screen and (max-width: 480px) {
+      width: 120px;
+      margin-right: 1rem;
     }
-    .share {
-      width: 140px;
-      height: 45px;
-      margin: 25px;
-      font-size: 11px;
-      letter-spacing: 2.5px;
-      font-weight: 500;
-      color: #000;
-      background-color: #fff;
-      border: none;
-      border-radius: 45px;
-      box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-      transition: all 0.3s ease 0s;
-      cursor: pointer;
-      outline: none;
-
-      &:hover {
-        background-color: #2ee59d;
-        box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-        color: #fff;
-        transform: translateY(-7px);
-      }
+    margin-bottom: 0;
+    margin-right: 2rem;
+  }
+  .share {
+    @media only screen and (max-width: 480px) {
+      width: 120px;
     }
+    margin-bottom: 0;
   }
 
   .result-inner {
     @media only screen and (max-width: 480px) {
       h1 {
+        font-size: 1.2em;
         padding: 1rem 2rem;
       }
+      padding: 1em 1.5em;
       margin-bottom: 2rem;
     }
 
-    width: 430px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 2em 2.5em;
     background-color: rgb(232, 247, 238);
     align-items: center;
-    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
 
     @media only screen and (min-width: 480px) {
       h1 {
@@ -76,56 +48,40 @@
     max-height: 200px;
   }
 
+  .result-desc {
+    div + div {
+      margin-top: 1rem;
+    }
+  }
+
   .icon-img {
     display: inline;
-    width: 50px;
-    height: 50px;
+    width: 45px;
+    height: 45px;
     margin: 0 10px;
-    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
   }
 
   .link-copy-container {
     display: flex;
     margin-bottom: 20px;
-    align-items: flex-end;
+    align-items: center;
     justify-content: center;
   }
 
   .url-textarea {
+    resize: none;
     display: inline-block;
     width: 130px;
-    height: 95px;
+    height: 45px;
+    margin-right: 1em;
   }
 
   .link-copy-btn {
     display: inline-block;
     width: 50px;
-    border-radius: 0px;
-  }
-
-  @media only screen and (max-width: 480px) {
-    .replay {
-      background-color: #2ee59d;
-      box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-      color: #fff;
-      width: 140px;
-      height: 45px;
-      font-size: 11px;
-      letter-spacing: 2.5px;
-      font-weight: 500;
-    }
-
-    .share {
-      background-color: #2ee59d;
-      box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-      color: #fff;
-      width: 140px;
-      height: 45px;
-      font-size: 11px;
-      letter-spacing: 2.5px;
-      font-weight: 500;
-      margin-left: 2rem;
-    }
+    border-radius: 0;
+    margin-bottom: 0;
   }
 }
 
@@ -138,24 +94,35 @@
 }
 
 .desc-wrapper {
-  padding: 2rem;
-  .resul-desc {
+  .result-desc {
     text-align: center;
     display: block;
   }
 }
 
 .buttons {
+  @media only screen and (max-width: 480px) {
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
   align-items: center;
+  margin-top: 25px;
 }
 
 .sns-share-btn {
-  box-shadow: none;
-  background: none;
-  width: fit-content;
+  @media (any-hover: hover) {
+    &:hover {
+      box-shadow: none;
+      background: none;
+    }
+  }
+  box-shadow: none !important;
+  background: none !important;
+  width: fit-content !important;
+  margin-bottom: 0 !important;
 
-  &:hover {
-    box-shadow: none;
-    background: none;
+  &:active {
+    box-shadow: none !important;
+    background: none !important;
   }
 }

--- a/src/styles/Test.scss
+++ b/src/styles/Test.scss
@@ -1,4 +1,5 @@
 @import 'colors';
+@import '../common/Button';
 
 .main-wrapper {
   
@@ -59,55 +60,19 @@
     font-size: 1.5em;
     font-weight: bold;
     line-height: 2rem;
+    margin-bottom: 1.2rem;
   }
 
-  button {
-    /* reset */
-    border: none;
-    cursor: pointer;
-    outline-style: none;
-
+  .btn_test {
     @media only screen and (max-width: 480px) {
-      width: 100%;
-     
-        background-color: $main-mint;
-        box-shadow: 0px 15px 20px $main-mint-dark;
-        color: #fff;
-     
-    
+      width: 80%;
+      margin-bottom: 1rem;
     }
-
-    /* position & size */
-    display: block;
-    margin: 0 auto;
-    width: 420px;
-    height: 45px;
-    border-radius: 45px;
-    margin-top: 2rem;
-
-    /* font */
+    height: 100%;
+    box-sizing: border-box;
+    padding: 0.5em 1em;
     font-size: 1em;
-    letter-spacing: 1.5px;
-    font-weight: 500;
-
-    /* color */
-    color: #000;
-    background-color: #fff;
-    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-
-    @media only screen and (min-width: 480px){
-
-    transition: all 0.3s ease 0s;
-
-   
-    &:hover {
-      background-color: #2ee59d;
-      box-shadow: 0px 15px 20px rgba(46, 229, 157, 0.4);
-      color: #fff;
-      transform: translateY(-7px);
-    }
-  }
-   
+    width: 420px;
   }
 }
 


### PR DESCRIPTION
1. 중복되는 버튼의 속성들을 mixin을 사용하여 재사용 가능하게 함
2. 이후 서비스의 확장성이 없음을 고려해 mixin을 개별 버튼에 가져다 쓰는 것이 아닌 mainwrapper 내의 버튼의 스타일로 지정함
3. 일부 btn_standard 속성과 일부 다른 스타일을 적용해야 하는 버튼은 스타일을 덮어씌웠음
4. 일부 레이아웃 수정

bug
480px 가 넘는데 터치디바이스인 경우(ex. 아이패드) hover 속성이 그대로 적용되어 의도대로 스타일이 적용되지 않음
-> any-hover:hover 속성을 사용하여 해결(IE 빼고 다 됨)